### PR TITLE
Initialize Next.js TypeScript app with Prismic integration

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,3 @@
+# Prismic configuration
+PRISMIC_REPOSITORY_NAME=your-repository-name
+PRISMIC_ACCESS_TOKEN=your-access-token

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# Testing
+/coverage
+
+# Next.js
+/.next/
+/out/
+
+# Production
+/build
+
+# Misc
+.DS_Store
+*.pem
+
+# Local env files
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # Codex
+
+This project was bootstrapped with a manual equivalent of `create-next-app` and
+pre-configured for Prismic.
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Fill in the values inside `.env.local` with your Prismic repository name and
+   an access token that has the desired permissions.
+
+3. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+4. Open [http://localhost:3000](http://localhost:3000) to see the application.
+
+## Prismic SDK check
+
+Once the environment variables are configured, visit
+[`/api/prismic-test`](http://localhost:3000/api/prismic-test?type=page) to run a
+`client.getAllByType` query against your repository. You can provide a custom
+Prismic custom type via the `type` query parameter if needed.

--- a/app/api/prismic-test/route.ts
+++ b/app/api/prismic-test/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { createClient, repositoryName } from "@/prismicio";
+
+export async function GET(request: Request) {
+  const client = createClient();
+  const url = new URL(request.url);
+  const type = url.searchParams.get("type") ?? "page";
+
+  if (!process.env.PRISMIC_REPOSITORY_NAME) {
+    return NextResponse.json(
+      {
+        ok: false,
+        repository: repositoryName,
+        error:
+          "PRISMIC_REPOSITORY_NAME is not configured. Update your .env.local file to continue.",
+      },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const documents = await client.getAllByType(type);
+
+    return NextResponse.json({
+      ok: true,
+      repository: repositoryName,
+      type,
+      total: documents.length,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown error connecting to Prismic";
+
+    return NextResponse.json(
+      {
+        ok: false,
+        repository: repositoryName,
+        type,
+        error: message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,74 @@
+:root {
+  --foreground-rgb: 15, 23, 42;
+  --background-start-rgb: 255, 255, 255;
+  --background-end-rgb: 226, 232, 240;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --foreground-rgb: 226, 232, 240;
+    --background-start-rgb: 15, 23, 42;
+    --background-end-rgb: 2, 6, 23;
+  }
+}
+
+* {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+}
+
+html,
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
+body {
+  color: rgb(var(--foreground-rgb));
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    rgb(var(--background-end-rgb))
+  )
+    rgb(var(--background-start-rgb));
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+a:hover {
+  text-decoration: none;
+}
+
+main.container {
+  margin: 0 auto;
+  max-width: 700px;
+  padding: 4rem 1.5rem 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+main.container h1 {
+  font-size: clamp(2.5rem, 5vw, 3rem);
+  font-weight: 600;
+}
+
+main.container section {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  background: rgba(148, 163, 184, 0.08);
+}
+
+main.container section h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Codex",
+  description: "A Next.js starter configured with Prismic",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <main className="container">
+      <h1>Next.js + Prismic starter</h1>
+      <p>
+        The project is ready to connect to your Prismic repository. Configure the
+        <code>.env.local</code> file with your repository name and access token,
+        then start the development server with <code>npm run dev</code>.
+      </p>
+      <section>
+        <h2>Prismic check</h2>
+        <p>
+          You can verify the SDK connection by visiting the
+          {" "}
+          <Link href="/api/prismic-test?type=page">/api/prismic-test</Link>
+          {" "}
+          endpoint once your environment variables are in place.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,20 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.prismic.io",
+        pathname: "/**"
+      },
+      {
+        protocol: "https",
+        hostname: "*.cdn.prismic.io",
+        pathname: "/**"
+      }
+    ]
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "codex",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "prismic:codegen": "prismic-ts-codegen"
+  },
+  "dependencies": {
+    "@prismicio/client": "^7.4.1",
+    "@prismicio/next": "^1.5.0",
+    "@prismicio/react": "^2.6.0",
+    "next": "14.2.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.6",
+    "prismic-ts-codegen": "^0.1.19",
+    "typescript": "^5.5.4"
+  }
+}

--- a/prismicio.ts
+++ b/prismicio.ts
@@ -1,0 +1,16 @@
+import * as prismic from "@prismicio/client";
+
+export const repositoryName =
+  process.env.PRISMIC_REPOSITORY_NAME ?? "your-repository-name";
+
+export const routes: prismic.ClientConfig["routes"] = [];
+
+export function createClient(config: prismic.ClientConfig = {}): prismic.Client {
+  const client = prismic.createClient(repositoryName, {
+    accessToken: process.env.PRISMIC_ACCESS_TOKEN,
+    routes,
+    ...config,
+  });
+
+  return client;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a TypeScript Next.js application using the app router structure and basic styling
- add Prismic dependencies with a `prismicio.ts` helper and environment variable placeholders for repository configuration
- configure image domains, documentation, and an API route to verify `client.getAllByType` connectivity

## Testing
- `npm install` *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d09e45333c832b9b06939a46109f9b