### PR TITLE
Implement Prismic image pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+.env.local
+public/i/
+.DS_Store
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # Codex
+
+## Prismic setup
+
+I tipi personalizzati sono sincronizzati nella cartella `customtypes/`:
+
+- `collection`: UID, titolo, descrizione breve, ordine e gruppo di relazioni verso i documenti `image_asset`.
+- `image_asset`: UID, immagine, didascalia, crediti e ordine.
+
+`sm.json` e `slicemachine.config.json` consentono la sincronizzazione con Slice Machine (`npx prismic sm --create-slice-machine`).
+
+## Pipeline immagini
+
+Usa [Sharp](https://sharp.pixelplumbing.com/) per generare asset responsive:
+
+```bash
+npm run build-images
+```
+
+Lo script scarica immagini da Prismic e crea varianti JPEG nelle directory `public/i/{collection}/w-{width}/`. Viene aggiornato anche il manifest JSON (`generated/image-manifest.json`) usato da `lib/images.ts` per esporre `srcSet`, `sizes`, hash e link `rel="preload"` dell'immagine successiva.
+
+### Variabili d'ambiente
+
+- `PRISMIC_REPOSITORY_NAME` o `PRISMIC_API_ENDPOINT`
+- `PRISMIC_ACCESS_TOKEN` (opzionale per repository pubblici)
+
+Lo script rimuove e rigenera il contenuto di `public/i/` ad ogni esecuzione.

--- a/customtypes/collection/index.json
+++ b/customtypes/collection/index.json
@@ -1,0 +1,58 @@
+{
+  "id": "collection",
+  "label": "Collection",
+  "repeatable": true,
+  "status": true,
+  "json": {
+    "Main": {
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "Slug",
+          "placeholder": "codex-collection"
+        }
+      },
+      "title": {
+        "type": "Text",
+        "config": {
+          "label": "Titolo",
+          "placeholder": "Titolo collezione"
+        }
+      },
+      "short_description": {
+        "type": "StructuredText",
+        "config": {
+          "label": "Descrizione breve",
+          "single": "paragraph",
+          "placeholder": "Riassunto sintetico della collezione"
+        }
+      },
+      "order": {
+        "type": "Number",
+        "config": {
+          "label": "Ordine",
+          "placeholder": "1"
+        }
+      },
+      "images": {
+        "type": "Group",
+        "config": {
+          "label": "Immagini",
+          "fields": {
+            "asset": {
+              "type": "Link",
+              "config": {
+                "label": "Image asset",
+                "select": "document",
+                "customtypes": [
+                  "image_asset"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "format": "custom"
+}

--- a/customtypes/image_asset/index.json
+++ b/customtypes/image_asset/index.json
@@ -1,0 +1,50 @@
+{
+  "id": "image_asset",
+  "label": "Image asset",
+  "repeatable": true,
+  "status": true,
+  "json": {
+    "Main": {
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "Slug",
+          "placeholder": "immagine-significativa"
+        }
+      },
+      "image": {
+        "type": "Image",
+        "config": {
+          "label": "Immagine",
+          "constraint": {
+            "width": 0,
+            "height": 0
+          },
+          "thumbnails": []
+        }
+      },
+      "caption": {
+        "type": "StructuredText",
+        "config": {
+          "label": "Didascalia",
+          "multi": "paragraph,em,strong,hyperlink"
+        }
+      },
+      "credits": {
+        "type": "Text",
+        "config": {
+          "label": "Crediti",
+          "placeholder": "Foto di ..."
+        }
+      },
+      "order": {
+        "type": "Number",
+        "config": {
+          "label": "Ordine",
+          "placeholder": "1"
+        }
+      }
+    }
+  },
+  "format": "custom"
+}

--- a/generated/image-manifest.json
+++ b/generated/image-manifest.json
@@ -1,0 +1,5 @@
+{
+  "generatedAt": null,
+  "widths": [],
+  "collections": {}
+}

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -1,0 +1,425 @@
+import manifestJson from "../generated/image-manifest.json" assert { type: "json" };
+
+export type ImageVariant = {
+  width: number;
+  height: number;
+  bytes: number;
+  aspectRatio: number;
+  src: string;
+};
+
+export type ImageEntry = {
+  slug: string;
+  documentId: string;
+  documentUid: string | null;
+  order: number;
+  caption: string | null;
+  credits: string | null;
+  alt: string | null;
+  hash: string;
+  variants: ImageVariant[];
+};
+
+export type CollectionEntry = {
+  slug: string;
+  title: string | null;
+  description: string | null;
+  order: number | null;
+  images: ImageEntry[];
+};
+
+export type ImageManifest = {
+  generatedAt: string | null;
+  widths: number[];
+  collections: Record<string, CollectionEntry>;
+};
+
+export type NavigationDirection = "forward" | "backward";
+
+export type PreloadLinkDescriptor = {
+  rel: "preload";
+  as: "image";
+  href: string;
+  imagesrcset: string;
+  imagesizes: string;
+  type: string;
+};
+
+export type ImageSourceOptions = {
+  sizes?: string;
+  direction?: NavigationDirection;
+  loop?: boolean;
+  preferLargest?: boolean;
+};
+
+export type ImageSource = {
+  src: string;
+  srcSet: string;
+  sizes: string;
+  hash: string;
+  width: number;
+  height: number;
+  image: ImageEntry;
+  collection: CollectionEntry;
+  preload?: PreloadLinkDescriptor | null;
+};
+
+type ManifestInput = {
+  generatedAt?: unknown;
+  widths?: unknown;
+  collections?: Record<string, unknown> | null;
+};
+
+const manifest: ImageManifest = normalizeManifest(manifestJson as ManifestInput);
+
+function normalizeManifest(data: ManifestInput): ImageManifest {
+  const generatedAt = typeof data.generatedAt === "string" ? data.generatedAt : null;
+  const widths = Array.isArray(data.widths)
+    ? data.widths
+        .map((value) => toNumeric(value))
+        .filter((value): value is number => value !== null)
+        .sort((a, b) => a - b)
+    : [];
+
+  const collections: Record<string, CollectionEntry> = {};
+
+  if (data.collections && typeof data.collections === "object") {
+    for (const [slug, rawEntry] of Object.entries(data.collections)) {
+      if (!rawEntry || typeof rawEntry !== "object") {
+        continue;
+      }
+
+      const entry = normalizeCollection(slug, rawEntry as Record<string, unknown>);
+      collections[entry.slug] = entry;
+    }
+  }
+
+  return {
+    generatedAt,
+    widths,
+    collections
+  };
+}
+
+function normalizeCollection(slug: string, data: Record<string, unknown>): CollectionEntry {
+  const normalizedSlug = asNonEmptyString(data.slug) ?? slug;
+  const title = asOptionalString(data.title);
+  const description = asOptionalString(data.description);
+  const order = toNumeric(data.order);
+  const imagesRaw = Array.isArray(data.images) ? (data.images as unknown[]) : [];
+  const images = imagesRaw
+    .map((value, index) => normalizeImage(value, index))
+    .filter((value): value is ImageEntry => value !== null);
+
+  images.sort(sortImages);
+
+  return {
+    slug: normalizedSlug,
+    title,
+    description,
+    order,
+    images
+  };
+}
+
+function normalizeImage(raw: unknown, index: number): ImageEntry | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+
+  const data = raw as Record<string, unknown>;
+  const slug = asNonEmptyString(data.slug) ?? `image-${index + 1}`;
+  const documentId = asNonEmptyString(data.documentId) ?? slug;
+  const documentUid = asOptionalString(data.documentUid);
+  const caption = asOptionalString(data.caption);
+  const credits = asOptionalString(data.credits);
+  const alt = asOptionalString(data.alt);
+  const order = toNumeric(data.order) ?? index;
+  const hash = asNonEmptyString(data.hash) ?? "";
+  const variantsRaw = Array.isArray(data.variants) ? (data.variants as unknown[]) : [];
+  const variants = variantsRaw
+    .map((variant) => normalizeVariant(variant))
+    .filter((variant): variant is ImageVariant => variant !== null)
+    .sort((a, b) => a.width - b.width);
+
+  if (variants.length === 0) {
+    return null;
+  }
+
+  return {
+    slug,
+    documentId,
+    documentUid,
+    order,
+    caption,
+    credits,
+    alt,
+    hash,
+    variants
+  };
+}
+
+function normalizeVariant(raw: unknown): ImageVariant | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+
+  const data = raw as Record<string, unknown>;
+  const width = toNumeric(data.width);
+  const height = toNumeric(data.height);
+  const bytes = toNumeric(data.bytes) ?? 0;
+  const src = asNonEmptyString(data.src);
+  const aspectRatio = toNumeric(data.aspectRatio);
+
+  if (!width || !height || !src) {
+    return null;
+  }
+
+  return {
+    width,
+    height,
+    bytes,
+    aspectRatio: aspectRatio ?? (height > 0 ? width / height : width),
+    src
+  };
+}
+
+function sortImages(a: ImageEntry, b: ImageEntry): number {
+  if (a.order !== b.order) {
+    return a.order - b.order;
+  }
+
+  return a.slug.localeCompare(b.slug);
+}
+
+function sortCollections(a: CollectionEntry, b: CollectionEntry): number {
+  const orderA = a.order ?? Number.POSITIVE_INFINITY;
+  const orderB = b.order ?? Number.POSITIVE_INFINITY;
+
+  if (orderA !== orderB) {
+    return orderA - orderB;
+  }
+
+  return a.slug.localeCompare(b.slug);
+}
+
+function asOptionalString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  return null;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  const optional = asOptionalString(value);
+  return optional && optional.length > 0 ? optional : null;
+}
+
+function toNumeric(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  return null;
+}
+
+function copyVariant(variant: ImageVariant): ImageVariant {
+  return { ...variant };
+}
+
+function copyImage(image: ImageEntry): ImageEntry {
+  return {
+    ...image,
+    variants: image.variants.map(copyVariant)
+  };
+}
+
+function copyCollection(entry: CollectionEntry): CollectionEntry {
+  return {
+    ...entry,
+    images: entry.images.map(copyImage)
+  };
+}
+
+function copyManifest(data: ImageManifest): ImageManifest {
+  const collections: Record<string, CollectionEntry> = {};
+  for (const [slug, entry] of Object.entries(data.collections)) {
+    collections[slug] = copyCollection(entry);
+  }
+
+  return {
+    generatedAt: data.generatedAt,
+    widths: data.widths.slice(),
+    collections
+  };
+}
+
+function buildSrcSet(variants: ImageVariant[]): string {
+  return variants.map((variant) => `${variant.src} ${variant.width}w`).join(", ");
+}
+
+function resolvePrimaryVariant(variants: ImageVariant[], preferLargest: boolean): ImageVariant {
+  return preferLargest ? variants[variants.length - 1] : variants[0];
+}
+
+function resolvePreload(
+  collection: CollectionEntry,
+  currentIndex: number,
+  direction: NavigationDirection,
+  sizes: string,
+  loop: boolean
+): PreloadLinkDescriptor | null {
+  if (collection.images.length <= 1) {
+    return null;
+  }
+
+  let targetIndex = direction === "backward" ? currentIndex - 1 : currentIndex + 1;
+
+  if (loop) {
+    const total = collection.images.length;
+    targetIndex = (targetIndex + total) % total;
+  }
+
+  if (targetIndex < 0 || targetIndex >= collection.images.length) {
+    return null;
+  }
+
+  const targetImage = collection.images[targetIndex];
+  if (!targetImage || targetImage.variants.length === 0) {
+    return null;
+  }
+
+  return {
+    rel: "preload",
+    as: "image",
+    href: targetImage.variants[targetImage.variants.length - 1].src,
+    imagesrcset: buildSrcSet(targetImage.variants),
+    imagesizes: sizes,
+    type: "image/jpeg"
+  };
+}
+
+export function getManifest(): ImageManifest {
+  return copyManifest(manifest);
+}
+
+export function getCollections(): CollectionEntry[] {
+  return Object.values(manifest.collections)
+    .map(copyCollection)
+    .sort(sortCollections);
+}
+
+export function getCollection(slug: string): CollectionEntry | undefined {
+  const entry = manifest.collections[slug];
+  return entry ? copyCollection(entry) : undefined;
+}
+
+export function getCollectionImage(
+  collectionSlug: string,
+  imageSlug: string
+): { collection: CollectionEntry; image: ImageEntry; index: number } | undefined {
+  const collection = manifest.collections[collectionSlug];
+  if (!collection) {
+    return undefined;
+  }
+
+  const index = collection.images.findIndex((image) => image.slug === imageSlug);
+  if (index === -1) {
+    return undefined;
+  }
+
+  const image = collection.images[index];
+
+  return {
+    collection: copyCollection(collection),
+    image: copyImage(image),
+    index
+  };
+}
+
+export function getImageSources(
+  collectionSlug: string,
+  imageSlug: string,
+  options: ImageSourceOptions = {}
+): ImageSource | undefined {
+  const record = manifest.collections[collectionSlug];
+  if (!record) {
+    return undefined;
+  }
+
+  const index = record.images.findIndex((image) => image.slug === imageSlug);
+  if (index === -1) {
+    return undefined;
+  }
+
+  const image = record.images[index];
+  if (image.variants.length === 0) {
+    return undefined;
+  }
+
+  const sizes = options.sizes ?? "100vw";
+  const preferLargest = options.preferLargest ?? false;
+  const primaryVariant = resolvePrimaryVariant(image.variants, preferLargest);
+  const srcSet = buildSrcSet(image.variants);
+  const preload = resolvePreload(
+    record,
+    index,
+    options.direction ?? "forward",
+    sizes,
+    options.loop ?? false
+  );
+
+  return {
+    src: primaryVariant.src,
+    srcSet,
+    sizes,
+    hash: image.hash,
+    width: primaryVariant.width,
+    height: primaryVariant.height,
+    image: copyImage(image),
+    collection: copyCollection(record),
+    preload
+  };
+}
+
+export function getNextImageSlug(
+  collectionSlug: string,
+  imageSlug: string,
+  direction: NavigationDirection = "forward",
+  loop = false
+): string | undefined {
+  const collection = manifest.collections[collectionSlug];
+  if (!collection) {
+    return undefined;
+  }
+
+  const index = collection.images.findIndex((image) => image.slug === imageSlug);
+  if (index === -1) {
+    return undefined;
+  }
+
+  let targetIndex = direction === "backward" ? index - 1 : index + 1;
+
+  if (loop) {
+    const total = collection.images.length;
+    targetIndex = (targetIndex + total) % total;
+  }
+
+  if (targetIndex < 0 || targetIndex >= collection.images.length) {
+    return undefined;
+  }
+
+  return collection.images[targetIndex]?.slug;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "codex",
+  "version": "1.0.0",
+  "private": true,
+  "description": "",
+  "type": "module",
+  "scripts": {
+    "build-images": "tsx scripts/generate-images.ts",
+    "prebuild": "npm run build-images",
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@prismicio/client": "^7.4.1",
+    "sharp": "^0.33.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.4",
+    "tsx": "^4.15.7",
+    "typescript": "^5.5.4"
+  }
+}

--- a/scripts/generate-images.ts
+++ b/scripts/generate-images.ts
@@ -1,0 +1,508 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import crypto from "node:crypto";
+import process from "node:process";
+import sharp from "sharp";
+import * as prismic from "@prismicio/client";
+
+type RichTextNode = { text?: string | null };
+type RichTextField = ReadonlyArray<RichTextNode> | null | undefined;
+
+type ContentRelationshipField = {
+  id?: string;
+  uid?: string | null;
+  type?: string;
+  link_type?: string | null;
+};
+
+type CollectionDocumentData = {
+  title?: string | null;
+  short_description?: RichTextField;
+  order?: number | string | null;
+  images?: Array<{
+    asset?: ContentRelationshipField | null;
+  }> | null;
+};
+
+type ImageAssetDocumentData = {
+  image?: {
+    url?: string | null;
+    alt?: string | null;
+    dimensions?: {
+      width?: number | null;
+      height?: number | null;
+    } | null;
+  } | null;
+  caption?: RichTextField;
+  credits?: string | null;
+  order?: number | string | null;
+};
+
+type CollectionDocument = {
+  id: string;
+  uid: string | null;
+  data: CollectionDocumentData;
+};
+
+type ImageAssetDocument = {
+  id: string;
+  uid: string | null;
+  data: ImageAssetDocumentData;
+};
+
+type ImageVariant = {
+  width: number;
+  height: number;
+  bytes: number;
+  aspectRatio: number;
+  src: string;
+};
+
+type ImageEntry = {
+  slug: string;
+  documentId: string;
+  documentUid: string | null;
+  order: number;
+  caption: string | null;
+  credits: string | null;
+  alt: string | null;
+  hash: string;
+  variants: ImageVariant[];
+};
+
+type CollectionEntry = {
+  slug: string;
+  title: string | null;
+  description: string | null;
+  order: number | null;
+  images: ImageEntry[];
+};
+
+type ImageManifest = {
+  generatedAt: string;
+  widths: number[];
+  collections: Record<string, CollectionEntry>;
+};
+
+type SliceMachineConfig = {
+  repositoryName?: string;
+  apiEndpoint?: string;
+};
+
+const BASE_WIDTHS = [480, 640, 768, 960, 1024, 1280, 1440, 1536, 1600, 1920] as const;
+const MAX_WIDTH = 3840;
+const WIDTH_PRESET = Array.from(
+  new Set<number>([
+    ...BASE_WIDTHS,
+    ...BASE_WIDTHS.map((width) => width * 2)
+  ])
+)
+  .filter((width) => width > 0 && width <= MAX_WIDTH)
+  .sort((a, b) => a - b);
+
+const OUTPUT_ROOT = path.resolve("public", "i");
+const MANIFEST_PATH = path.resolve("generated", "image-manifest.json");
+
+const imageBufferCache = new Map<string, Buffer>();
+
+sharp.cache(false);
+
+function toPlainText(value: unknown): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (Array.isArray(value)) {
+    const text = (value as RichTextNode[])
+      .map((node) => (typeof node?.text === "string" ? node.text : ""))
+      .join("\n")
+      .trim();
+
+    return text.length > 0 ? text : null;
+  }
+
+  return null;
+}
+
+function toNumeric(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  return null;
+}
+
+function slugifySegment(value: string | null | undefined, fallback: string): string {
+  const candidate = (value ?? "").toString().trim();
+  const normalisedCandidate = candidate
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+
+  if (normalisedCandidate.length > 0) {
+    return normalisedCandidate;
+  }
+
+  const fallbackNormalised = fallback
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return fallbackNormalised.length > 0 ? fallbackNormalised : "asset";
+}
+
+function ensureUniqueSlug(base: string, used: Set<string>): string {
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+
+  let index = 2;
+  let candidate = `${base}-${index}`;
+
+  while (used.has(candidate)) {
+    index += 1;
+    candidate = `${base}-${index}`;
+  }
+
+  used.add(candidate);
+  return candidate;
+}
+
+function computeTargetWidths(originalWidth?: number | null): number[] {
+  const hasOriginal = typeof originalWidth === "number" && Number.isFinite(originalWidth) && originalWidth > 0;
+  const max = hasOriginal ? Math.min(Math.round(originalWidth), MAX_WIDTH) : MAX_WIDTH;
+  const widths = new Set<number>();
+
+  for (const preset of WIDTH_PRESET) {
+    if (preset <= max) {
+      widths.add(preset);
+    }
+  }
+
+  if (hasOriginal) {
+    widths.add(max);
+  }
+
+  const result = Array.from(widths)
+    .filter((width) => width > 0 && width <= max)
+    .sort((a, b) => a - b);
+
+  if (result.length === 0) {
+    result.push(hasOriginal ? max : WIDTH_PRESET[0] ?? 480);
+  }
+
+  return result;
+}
+
+async function loadSliceMachineConfig(): Promise<SliceMachineConfig> {
+  const config: SliceMachineConfig = {};
+
+  try {
+    const raw = await fs.readFile("slicemachine.config.json", "utf8");
+    const parsed = JSON.parse(raw);
+
+    if (parsed && typeof parsed === "object") {
+      if (typeof parsed.repositoryName === "string") {
+        config.repositoryName = parsed.repositoryName;
+      }
+
+      if (typeof parsed.apiEndpoint === "string") {
+        config.apiEndpoint = parsed.apiEndpoint;
+      }
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code && code !== "ENOENT") {
+      console.warn("Impossibile leggere slicemachine.config.json:", error);
+    }
+  }
+
+  if (!config.apiEndpoint) {
+    try {
+      const raw = await fs.readFile("sm.json", "utf8");
+      const parsed = JSON.parse(raw);
+
+      if (parsed && typeof parsed === "object" && typeof parsed.apiEndpoint === "string") {
+        config.apiEndpoint = parsed.apiEndpoint;
+        if (!config.repositoryName) {
+          const match = /https?:\/\/([^.]+)\./.exec(parsed.apiEndpoint);
+          if (match) {
+            config.repositoryName = match[1];
+          }
+        }
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code && code !== "ENOENT") {
+        console.warn("Impossibile leggere sm.json:", error);
+      }
+    }
+  }
+
+  if (!config.apiEndpoint && config.repositoryName) {
+    config.apiEndpoint = `https://${config.repositoryName}.cdn.prismic.io/api/v2`;
+  }
+
+  return config;
+}
+
+async function ensureOutputRoot(): Promise<void> {
+  await fs.rm(OUTPUT_ROOT, { recursive: true, force: true });
+  await fs.mkdir(OUTPUT_ROOT, { recursive: true });
+}
+
+async function fetchImageBuffer(url: string): Promise<Buffer> {
+  const cached = imageBufferCache.get(url);
+  if (cached) {
+    return cached;
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Download non riuscito per ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  imageBufferCache.set(url, buffer);
+  return buffer;
+}
+
+async function generateVariants(params: {
+  buffer: Buffer;
+  collectionSlug: string;
+  imageSlug: string;
+  originalWidth?: number | null;
+  originalHeight?: number | null;
+}): Promise<ImageVariant[]> {
+  const { buffer, collectionSlug, imageSlug, originalWidth, originalHeight } = params;
+  const targetWidths = computeTargetWidths(originalWidth);
+  const variants: ImageVariant[] = [];
+  const seen = new Set<number>();
+
+  for (const targetWidth of targetWidths) {
+    const pipeline = sharp(buffer).resize({
+      width: targetWidth,
+      fit: "inside",
+      withoutEnlargement: true
+    });
+
+    const { data, info } = await pipeline.jpeg({
+      quality: 82,
+      chromaSubsampling: "4:2:0",
+      mozjpeg: true,
+      progressive: true
+    }).toBuffer({ resolveWithObject: true });
+
+    const width = info.width ?? targetWidth;
+    if (seen.has(width)) {
+      continue;
+    }
+    seen.add(width);
+
+    const height = info.height ?? (originalWidth && originalHeight && originalWidth > 0
+      ? Math.round((width / originalWidth) * originalHeight)
+      : width);
+
+    const aspectRatio = height > 0 ? width / height : width;
+    const directory = path.join(OUTPUT_ROOT, collectionSlug, `w-${width}`);
+    await fs.mkdir(directory, { recursive: true });
+    const filePath = path.join(directory, `${imageSlug}.jpg`);
+    await fs.writeFile(filePath, data);
+
+    variants.push({
+      width,
+      height,
+      bytes: info.size ?? data.length,
+      aspectRatio,
+      src: `/i/${collectionSlug}/w-${width}/${imageSlug}.jpg`
+    });
+  }
+
+  variants.sort((a, b) => a.width - b.width);
+  return variants;
+}
+
+async function writeManifest(manifest: ImageManifest): Promise<void> {
+  await fs.mkdir(path.dirname(MANIFEST_PATH), { recursive: true });
+  await fs.writeFile(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+async function main(): Promise<void> {
+  const sliceMachineConfig = await loadSliceMachineConfig();
+  const repositoryName = process.env.PRISMIC_REPOSITORY_NAME ?? sliceMachineConfig.repositoryName;
+  const apiEndpoint = process.env.PRISMIC_API_ENDPOINT ?? sliceMachineConfig.apiEndpoint ?? (repositoryName ? `https://${repositoryName}.cdn.prismic.io/api/v2` : null);
+
+  if (!apiEndpoint) {
+    throw new Error("Impossibile determinare l'endpoint API di Prismic. Impostare PRISMIC_API_ENDPOINT o repositoryName.");
+  }
+
+  const client = prismic.createClient(apiEndpoint, {
+    accessToken: process.env.PRISMIC_ACCESS_TOKEN || undefined,
+    fetch
+  });
+
+  await ensureOutputRoot();
+
+  const [collectionsRaw, imageAssetsRaw] = await Promise.all([
+    client.getAllByType("collection", { lang: "*" }),
+    client.getAllByType("image_asset", { lang: "*" })
+  ]);
+
+  const collections = collectionsRaw as unknown as CollectionDocument[];
+  const imageAssets = imageAssetsRaw as unknown as ImageAssetDocument[];
+
+  const imageById = new Map<string, ImageAssetDocument>();
+  const imageByUid = new Map<string, ImageAssetDocument>();
+
+  for (const image of imageAssets) {
+    imageById.set(image.id, image);
+    if (image.uid) {
+      imageByUid.set(image.uid, image);
+    }
+  }
+
+  const manifest: ImageManifest = {
+    generatedAt: new Date().toISOString(),
+    widths: WIDTH_PRESET.slice(),
+    collections: {}
+  };
+
+  let totalCollections = 0;
+  let totalImages = 0;
+  let totalVariants = 0;
+
+  for (const collection of collections) {
+    const collectionSlug = slugifySegment(collection.uid, collection.id);
+    const usedSlugs = new Set<string>();
+    const description = toPlainText(collection.data.short_description);
+    const title = toPlainText(collection.data.title);
+    const order = toNumeric(collection.data.order);
+    const groupItems = Array.isArray(collection.data.images) ? collection.data.images : [];
+    const images: ImageEntry[] = [];
+
+    for (let index = 0; index < groupItems.length; index += 1) {
+      const groupItem = groupItems[index];
+      const relationship = groupItem?.asset;
+
+      if (!relationship || (relationship.link_type && relationship.link_type !== "Document")) {
+        continue;
+      }
+
+      if (relationship.type && relationship.type !== "image_asset") {
+        continue;
+      }
+
+      let imageDoc: ImageAssetDocument | undefined;
+
+      if (relationship.id && imageById.has(relationship.id)) {
+        imageDoc = imageById.get(relationship.id);
+      } else if (relationship.uid && imageByUid.has(relationship.uid)) {
+        imageDoc = imageByUid.get(relationship.uid);
+      }
+
+      if (!imageDoc) {
+        console.warn(`Nessun documento image_asset trovato per la relazione alla posizione ${index} della collezione ${collectionSlug}.`);
+        continue;
+      }
+
+      const imageField = imageDoc.data.image;
+      const imageUrl = imageField?.url ?? null;
+
+      if (!imageUrl) {
+        console.warn(`Documento image_asset ${imageDoc.id} privo di URL immagine, ignorato.`);
+        continue;
+      }
+
+      const baseSlug = slugifySegment(imageDoc.uid, imageDoc.id);
+      const imageSlug = ensureUniqueSlug(baseSlug, usedSlugs);
+
+      const buffer = await fetchImageBuffer(imageUrl);
+      const dimensions = imageField?.dimensions ?? {};
+      const variants = await generateVariants({
+        buffer,
+        collectionSlug,
+        imageSlug,
+        originalWidth: dimensions?.width ?? null,
+        originalHeight: dimensions?.height ?? null
+      });
+
+      if (variants.length === 0) {
+        console.warn(`Impossibile generare varianti per l'immagine ${imageDoc.id}.`);
+        continue;
+      }
+
+      const hash = crypto.createHash("sha256").update(buffer).digest("hex");
+      const caption = toPlainText(imageDoc.data.caption);
+      const credits = toPlainText(imageDoc.data.credits);
+      const alt = toPlainText(imageField?.alt);
+      const orderValue = toNumeric(imageDoc.data.order) ?? index;
+
+      images.push({
+        slug: imageSlug,
+        documentId: imageDoc.id,
+        documentUid: imageDoc.uid ?? null,
+        order: orderValue,
+        caption,
+        credits,
+        alt,
+        hash,
+        variants
+      });
+
+      totalImages += 1;
+      totalVariants += variants.length;
+    }
+
+    images.sort((a, b) => {
+      if (a.order !== b.order) {
+        return a.order - b.order;
+      }
+
+      return a.slug.localeCompare(b.slug);
+    });
+
+    manifest.collections[collectionSlug] = {
+      slug: collectionSlug,
+      title,
+      description,
+      order,
+      images
+    };
+
+    totalCollections += 1;
+  }
+
+  await writeManifest(manifest);
+
+  console.log(
+    `Generati ${totalVariants} file derivati per ${totalImages} immagini in ${totalCollections} collezioni.`
+  );
+  console.log(`Manifest salvato in ${path.relative(process.cwd(), MANIFEST_PATH)}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/slicemachine.config.json
+++ b/slicemachine.config.json
@@ -1,0 +1,8 @@
+{
+  "repositoryName": "codex",
+  "adapter": "@slicemachine/adapter-next",
+  "libraries": [
+    "./slices"
+  ],
+  "localSliceSimulatorURL": "http://localhost:3000/slice-simulator"
+}

--- a/sm.json
+++ b/sm.json
@@ -1,0 +1,7 @@
+{
+  "apiEndpoint": "https://codex.cdn.prismic.io/api/v2",
+  "libraries": [
+    "./slices"
+  ],
+  "localSliceSimulatorURL": "http://localhost:3000/slice-simulator"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "types": [
+      "node"
+    ],
+    "baseUrl": "."
+  },
+  "include": [
+    "scripts/**/*.ts",
+    "lib/**/*.ts",
+    "generated/**/*.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Prismic custom type definitions for collections and image assets together with Slice Machine configuration
- implement a Sharp-based generator that syncs Prismic media into responsive JPEG variants and a manifest consumed by the app
- provide TypeScript helpers for srcset/sizes/preload data and document the workflow in the README

## Testing
- not run (npm install was blocked by registry 403 responses in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d09e4ebd98832b84291c53255a00b0