### PR TITLE
Add Prismic-indexed gallery navigation with dynamic viewer

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/app/[collection]/page.tsx
+++ b/app/[collection]/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import CollectionPageClient from '@/components/CollectionPageClient';
+import { getCollection, getCollectionSlugs } from '@/lib/prismic';
+
+interface PageProps {
+  params: { collection: string };
+  searchParams: Record<string, string | string[] | undefined>;
+}
+
+export async function generateStaticParams() {
+  const slugs = await getCollectionSlugs();
+  return slugs.map((slug) => ({ collection: slug }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const collection = await getCollection(params.collection);
+  if (!collection) {
+    return { title: 'Collezione non trovata — Archivio fotografico' };
+  }
+
+  const description =
+    collection.summary ||
+    (collection.descriptionHtml ? truncate(stripHtml(collection.descriptionHtml), 160) : undefined);
+
+  return {
+    title: `${collection.title} — Archivio fotografico`,
+    description,
+    openGraph: {
+      title: `${collection.title} — Archivio fotografico`,
+      description,
+      images:
+        collection.gallery.length > 0
+          ? [
+              {
+                url: collection.gallery[0].url,
+                width: collection.gallery[0].width,
+                height: collection.gallery[0].height,
+                alt: collection.gallery[0].alt
+              }
+            ]
+          : undefined
+    }
+  } satisfies Metadata;
+}
+
+export const revalidate = 120;
+
+export default async function CollectionPage({ params, searchParams }: PageProps) {
+  const collection = await getCollection(params.collection);
+  if (!collection) {
+    notFound();
+  }
+
+  const rawParam = searchParams?.p;
+  const parsed = parseParam(rawParam);
+  const initialIndex = clamp(parsed - 1, collection.gallery.length);
+
+  return <CollectionPageClient collection={collection} initialIndex={initialIndex} />;
+}
+
+function parseParam(value: string | string[] | undefined) {
+  if (!value) return 1;
+  const candidate = Array.isArray(value) ? value[0] : value;
+  const parsed = Number.parseInt(candidate ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 1;
+  return parsed;
+}
+
+function clamp(index: number, total: number) {
+  if (total === 0) return 0;
+  if (!Number.isFinite(index)) return 0;
+  return Math.max(0, Math.min(total - 1, index));
+}
+
+function stripHtml(value: string) {
+  return value.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, limit: number) {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit - 1)}…`;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,61 @@
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: #0b0b0c;
+  color: #f4f4f5;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  letter-spacing: 0.01em;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+}
+
+@media (pointer: fine) {
+  html,
+  body,
+  a,
+  button {
+    cursor: none;
+  }
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import RouteTransition from '@/components/RouteTransition';
+import DynamicCursor from '@/components/DynamicCursor';
+
+export const metadata: Metadata = {
+  title: 'Codex — Archivio fotografico',
+  description:
+    'Archivio digitale di collezioni fotografiche: navigazione rapida, miniature e screensaver dinamico.'
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="it">
+      <body>
+        <DynamicCursor />
+        <RouteTransition>
+          <main>{children}</main>
+        </RouteTransition>
+      </body>
+    </html>
+  );
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,0 +1,95 @@
+.container {
+  padding: min(18vh, 10rem) 6vw 8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(3rem, 8vw, 5.5rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.intro {
+  max-width: 48rem;
+  font-size: 1rem;
+  line-height: 1.8;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.itemLink {
+  font-size: clamp(1.4rem, 3.5vw, 2.4rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.itemLink span {
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+}
+
+.count {
+  font-size: 0.7rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.summary {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 4rem 1.5rem 5rem;
+    gap: 2.5rem;
+  }
+
+  .item {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+  }
+
+  .meta {
+    align-items: flex-start;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import styles from './page.module.css';
+import { getCollectionsIndex } from '@/lib/prismic';
+
+export const revalidate = 120;
+
+export default async function IndexPage() {
+  const collections = await getCollectionsIndex();
+  const totalShots = collections.reduce((sum, item) => sum + item.count, 0);
+
+  return (
+    <section className={styles.container}>
+      <header>
+        <h1 className={styles.title}>Archivio fotografico</h1>
+        <p className={styles.intro}>
+          Elenco delle serie ordinate direttamente da Prismic. {collections.length} collezioni,{' '}
+          {totalShots} scatti complessivi.
+        </p>
+      </header>
+
+      <ol className={styles.list}>
+        {collections.map((collection) => (
+          <li key={collection.slug} className={styles.item}>
+            <Link
+              href={`/${collection.slug}`}
+              className={styles.itemLink}
+              data-cursor-label={`Apri ${collection.slug}`}
+            >
+              <span>{collection.slug}</span>
+              {collection.title}
+            </Link>
+            <div className={styles.meta}>
+              <span className={styles.count}>{formatShots(collection.count)}</span>
+              {collection.summary && <span className={styles.summary}>{collection.summary}</span>}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function formatShots(value: number) {
+  if (value === 1) return '1 scatto';
+  return `${value} scatti`;
+}

--- a/components/CollectionHeader.module.css
+++ b/components/CollectionHeader.module.css
@@ -1,0 +1,128 @@
+.header {
+  padding: 2.5rem 6vw 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.topRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.backLink {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+  transition: color 0.2s ease;
+}
+
+.backLink:hover {
+  color: #ffffff;
+}
+
+.counter {
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.counter strong {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2.5rem, 5vw, 3.8rem);
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.summary {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+}
+
+.description {
+  max-width: 50rem;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.description :global(p) {
+  margin: 0.25rem 0;
+}
+
+.metadata {
+  display: grid;
+  gap: 0.4rem 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.metadata dt {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.metadata dd {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.toggleButton {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(20, 20, 20, 0.65);
+  padding: 0.65rem 1.35rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.toggleButton:hover {
+  border-color: rgba(255, 255, 255, 0.45);
+  background: rgba(36, 36, 36, 0.85);
+}
+
+.toggleButtonActive {
+  border-color: rgba(255, 255, 255, 0.45);
+  background: rgba(36, 36, 36, 0.85);
+}
+
+@media (max-width: 768px) {
+  .header {
+    padding: 2rem 1.5rem 1rem;
+  }
+
+  .metadata {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}

--- a/components/CollectionHeader.tsx
+++ b/components/CollectionHeader.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import styles from './CollectionHeader.module.css';
+import type { CollectionMetadataEntry } from '@/lib/prismic';
+
+interface CollectionHeaderProps {
+  title: string;
+  summary?: string;
+  descriptionHtml?: string;
+  metadata?: CollectionMetadataEntry[];
+  currentIndex: number;
+  total: number;
+  thumbnailsOpen: boolean;
+  onToggleThumbnails: () => void;
+}
+
+const fade = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.5, ease: [0.33, 1, 0.68, 1] }
+};
+
+export default function CollectionHeader({
+  title,
+  summary,
+  descriptionHtml,
+  metadata,
+  currentIndex,
+  total,
+  thumbnailsOpen,
+  onToggleThumbnails
+}: CollectionHeaderProps) {
+  return (
+    <motion.header
+      className={styles.header}
+      initial={fade.initial}
+      animate={fade.animate}
+      transition={fade.transition}
+    >
+      <div className={styles.topRow}>
+        <Link href="/" className={styles.backLink} data-cursor-label="Indice">
+          Torna all&apos;indice
+        </Link>
+        <div className={styles.counter} aria-live="polite">
+          <strong>{String(currentIndex + 1).padStart(2, '0')}</strong>
+          {' / '}
+          {String(total).padStart(2, '0')}
+        </div>
+      </div>
+
+      <div className={styles.titleBlock}>
+        <h1 className={styles.title}>{title}</h1>
+        {summary && <p className={styles.summary}>{summary}</p>}
+      </div>
+
+      {descriptionHtml && (
+        <div
+          className={styles.description}
+          dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+        />
+      )}
+
+      {metadata && metadata.length > 0 && (
+        <dl className={styles.metadata}>
+          {metadata.map((entry) => (
+            <div key={`${entry.label}-${entry.value}`}>
+              <dt>{entry.label}</dt>
+              <dd>{entry.value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={`${styles.toggleButton} ${thumbnailsOpen ? styles.toggleButtonActive : ''}`.trim()}
+          onClick={onToggleThumbnails}
+          data-cursor-label={thumbnailsOpen ? 'Chiudi miniature' : 'Apri miniature'}
+          aria-pressed={thumbnailsOpen}
+        >
+          {thumbnailsOpen ? 'Nascondi miniature' : 'Mostra miniature'}
+        </button>
+      </div>
+    </motion.header>
+  );
+}

--- a/components/CollectionPageClient.module.css
+++ b/components/CollectionPageClient.module.css
@@ -1,0 +1,7 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding-bottom: 4rem;
+  gap: 1rem;
+}

--- a/components/CollectionPageClient.tsx
+++ b/components/CollectionPageClient.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import CollectionHeader from './CollectionHeader';
+import GalleryViewer from './GalleryViewer';
+import ThumbnailStrip from './ThumbnailStrip';
+import styles from './CollectionPageClient.module.css';
+import type { ResolvedCollection } from '@/lib/prismic';
+
+interface CollectionPageClientProps {
+  collection: ResolvedCollection;
+  initialIndex: number;
+}
+
+export default function CollectionPageClient({
+  collection,
+  initialIndex
+}: CollectionPageClientProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const total = collection.gallery.length;
+  const [activeIndex, setActiveIndex] = useState(() => clamp(initialIndex, total));
+  const [thumbnailsOpen, setThumbnailsOpen] = useState(false);
+
+  useEffect(() => {
+    setActiveIndex(clamp(initialIndex, total));
+  }, [initialIndex, total]);
+
+  useEffect(() => {
+    setThumbnailsOpen(false);
+  }, [collection.slug]);
+
+  useEffect(() => {
+    const param = searchParams?.get('p');
+    if (!param) {
+      if (activeIndex !== 0) {
+        setActiveIndex(0);
+      }
+      return;
+    }
+    const parsed = Number.parseInt(param, 10);
+    const next = Number.isFinite(parsed) ? clamp(parsed - 1, total) : 0;
+    if (next !== activeIndex) {
+      setActiveIndex(next);
+    }
+  }, [activeIndex, searchParams, total]);
+
+  const updateUrl = useCallback(
+    (index: number) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? '');
+      if (index > 0) {
+        params.set('p', String(index + 1));
+      } else {
+        params.delete('p');
+      }
+      const query = params.toString();
+      const target = query ? `${pathname}?${query}` : pathname;
+      router.replace(target, { scroll: false });
+    },
+    [pathname, router, searchParams]
+  );
+
+  const handleIndexChange = useCallback(
+    (index: number) => {
+      const next = clamp(index, total);
+      setActiveIndex(next);
+      updateUrl(next);
+    },
+    [total, updateUrl]
+  );
+
+  const handleSelectFromStrip = useCallback(
+    (index: number) => {
+      handleIndexChange(index);
+    },
+    [handleIndexChange]
+  );
+
+  const handleToggleThumbnails = useCallback(() => {
+    setThumbnailsOpen((value) => !value);
+  }, []);
+
+  const handleExit = useCallback(() => {
+    router.push('/', { scroll: false });
+  }, [router]);
+
+  return (
+    <div className={styles.container}>
+      <CollectionHeader
+        title={collection.title}
+        summary={collection.summary}
+        descriptionHtml={collection.descriptionHtml}
+        metadata={collection.metadata}
+        currentIndex={activeIndex}
+        total={total}
+        thumbnailsOpen={thumbnailsOpen}
+        onToggleThumbnails={handleToggleThumbnails}
+      />
+      <GalleryViewer
+        images={collection.gallery}
+        initialIndex={activeIndex}
+        onIndexChange={handleIndexChange}
+        onExit={handleExit}
+      />
+      <ThumbnailStrip
+        images={collection.gallery}
+        activeIndex={activeIndex}
+        isOpen={thumbnailsOpen}
+        onSelect={handleSelectFromStrip}
+      />
+    </div>
+  );
+}
+
+function clamp(index: number, total: number) {
+  if (total === 0) return 0;
+  if (!Number.isFinite(index)) return 0;
+  return Math.max(0, Math.min(total - 1, index));
+}

--- a/components/DynamicCursor.module.css
+++ b/components/DynamicCursor.module.css
@@ -1,0 +1,42 @@
+.cursor {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 10000;
+  pointer-events: none;
+  mix-blend-mode: difference;
+  will-change: transform, opacity;
+}
+
+.inner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  transform: translate(-50%, -50%);
+}
+
+.dot {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.35);
+}
+
+.label {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(12, 12, 12, 0.75);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px), (pointer: coarse) {
+  .cursor {
+    display: none;
+  }
+}

--- a/components/DynamicCursor.tsx
+++ b/components/DynamicCursor.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { AnimatePresence, motion, useMotionValue, useSpring } from 'framer-motion';
+import { useEffect, useMemo, useState } from 'react';
+import styles from './DynamicCursor.module.css';
+
+const springConfig = { stiffness: 240, damping: 28, mass: 0.35 };
+
+const INTERACTIVE_SELECTOR = '[data-cursor-label],a,button,[role="button"],label';
+
+function extractLabel(node: HTMLElement | null): string | null {
+  if (!node) return null;
+  const interactive = node.closest<HTMLElement>(INTERACTIVE_SELECTOR);
+  if (!interactive) return null;
+  const fromDataset = interactive.dataset.cursorLabel;
+  const aria = interactive.getAttribute('aria-label');
+  const text = interactive.textContent?.trim();
+  const label = fromDataset || aria || text;
+  return label ? label.replace(/\s+/g, ' ').trim() : null;
+}
+
+export default function DynamicCursor() {
+  const x = useSpring(useMotionValue(-100), springConfig);
+  const y = useSpring(useMotionValue(-100), springConfig);
+  const [visible, setVisible] = useState(false);
+  const [label, setLabel] = useState<string | null>(null);
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const media = window.matchMedia('(pointer: fine)');
+    const update = () => setEnabled(media.matches);
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+
+    const handleMove = (event: PointerEvent) => {
+      x.set(event.clientX);
+      y.set(event.clientY);
+      setVisible(true);
+    };
+
+    const handleLeave = () => setVisible(false);
+
+    const handlePointerOver = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null;
+      const nextLabel = extractLabel(target);
+      setLabel(nextLabel);
+    };
+
+    const handlePointerOut = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null;
+      const related = event.relatedTarget as HTMLElement | null;
+      if (target?.closest(INTERACTIVE_SELECTOR)) {
+        if (related && related.closest(INTERACTIVE_SELECTOR)) {
+          return;
+        }
+      }
+      setLabel(null);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerdown', handleMove);
+    window.addEventListener('blur', handleLeave);
+    document.addEventListener('pointerleave', handleLeave);
+    document.addEventListener('pointerover', handlePointerOver);
+    document.addEventListener('pointerout', handlePointerOut);
+
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerdown', handleMove);
+      window.removeEventListener('blur', handleLeave);
+      document.removeEventListener('pointerleave', handleLeave);
+      document.removeEventListener('pointerover', handlePointerOver);
+      document.removeEventListener('pointerout', handlePointerOut);
+    };
+  }, [enabled, x, y]);
+
+  const labelNode = useMemo(() => {
+    if (!label) return null;
+    return label.length > 36 ? `${label.slice(0, 33)}…` : label;
+  }, [label]);
+
+  if (!enabled) return null;
+
+  return (
+    <motion.div
+      className={styles.cursor}
+      style={{ x, y, opacity: visible ? 1 : 0 }}
+      aria-hidden
+    >
+      <div className={styles.inner}>
+        <span className={styles.dot} />
+        <AnimatePresence mode="wait">
+          {labelNode && (
+            <motion.span
+              key={labelNode}
+              className={styles.label}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 6 }}
+              transition={{ duration: 0.18, ease: [0.4, 0, 0.2, 1] }}
+            >
+              {labelNode}
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  );
+}

--- a/components/GalleryViewer.module.css
+++ b/components/GalleryViewer.module.css
@@ -1,0 +1,134 @@
+.viewer {
+  padding: 1rem 6vw 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.canvas {
+  position: relative;
+  width: 100%;
+  min-height: min(70vh, 70vw);
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.08), rgba(0, 0, 0, 0.85));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  isolation: isolate;
+}
+
+.canvas img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+  mix-blend-mode: lighten;
+  background: rgba(0, 0, 0, 0.9);
+}
+
+.interactionLayer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  pointer-events: none;
+}
+
+.navigationZone {
+  flex: 1;
+  pointer-events: auto;
+  background: transparent;
+  border: none;
+  margin: 0;
+  padding: 0;
+  color: transparent;
+}
+
+.navigationZoneLeft {
+  cursor: w-resize;
+}
+
+.navigationZoneRight {
+  cursor: e-resize;
+}
+
+.navigationZone:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: -6px;
+}
+
+.pointerHint {
+  position: absolute;
+  bottom: 1.5rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(16, 16, 16, 0.65);
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  pointer-events: none;
+}
+
+.pointerHintLeft {
+  left: 1.5rem;
+}
+
+.pointerHintRight {
+  right: 1.5rem;
+}
+
+.caption {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem 2.5rem;
+  align-items: flex-start;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.captionTitle {
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.captionDetails {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  opacity: 0.7;
+}
+
+.captionDetails span::before {
+  content: '•';
+  margin-right: 0.4rem;
+  opacity: 0.4;
+}
+
+.screensaverBadge {
+  align-self: flex-end;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.65rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 768px) {
+  .viewer {
+    padding: 1rem 1.5rem 2.5rem;
+  }
+
+  .canvas {
+    border-radius: 1rem;
+    min-height: 60vh;
+  }
+
+  .pointerHint {
+    display: none;
+  }
+}

--- a/components/GalleryViewer.tsx
+++ b/components/GalleryViewer.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import styles from './GalleryViewer.module.css';
+import type { GalleryImage } from '@/lib/prismic';
+import { useScreensaver } from '@/hooks/useScreensaver';
+
+interface GalleryViewerProps {
+  images: GalleryImage[];
+  initialIndex: number;
+  onIndexChange?: (index: number) => void;
+  onExit?: () => void;
+}
+
+export default function GalleryViewer({
+  images,
+  initialIndex,
+  onIndexChange,
+  onExit
+}: GalleryViewerProps) {
+  const [current, setCurrent] = useState(() => clampIndex(initialIndex, images.length));
+  const containerRef = useRef<HTMLDivElement>(null);
+  const currentRef = useRef(current);
+
+  useEffect(() => {
+    setCurrent(clampIndex(initialIndex, images.length));
+  }, [initialIndex, images.length]);
+
+  useEffect(() => {
+    currentRef.current = current;
+  }, [current]);
+
+  useEffect(() => {
+    containerRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  const { isActive, nextIndex, registerInteraction } = useScreensaver(images.length, current);
+
+  useEffect(() => {
+    if (nextIndex == null || nextIndex === current) return;
+    setCurrent(nextIndex);
+    onIndexChange?.(nextIndex);
+  }, [current, nextIndex, onIndexChange]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || images.length < 2) return;
+    const next = (current + 1) % images.length;
+    const url = images[next]?.url;
+    if (!url) return;
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.as = 'image';
+    link.href = url;
+    document.head.appendChild(link);
+    return () => {
+      if (link.parentNode) {
+        link.parentNode.removeChild(link);
+      }
+    };
+  }, [current, images]);
+
+  const goTo = useCallback(
+    (index: number) => {
+      if (!images.length) return;
+      const next = wrapIndex(index, images.length);
+      setCurrent(next);
+      onIndexChange?.(next);
+      registerInteraction();
+    },
+    [images.length, onIndexChange, registerInteraction]
+  );
+
+  const handleNext = useCallback(() => {
+    goTo(currentRef.current + 1);
+  }, [goTo]);
+
+  const handlePrevious = useCallback(() => {
+    goTo(currentRef.current - 1);
+  }, [goTo]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        handleNext();
+      } else if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        handlePrevious();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        registerInteraction();
+        onExit?.();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleNext, handlePrevious, onExit, registerInteraction]);
+
+  const activeImage = images[current];
+
+  const captionDetails = useMemo(() => {
+    if (!activeImage?.details?.length) return null;
+    return activeImage.details.map((detail) => (
+      <span key={`${detail.label}-${detail.value}`}>{`${detail.label}: ${detail.value}`}</span>
+    ));
+  }, [activeImage?.details]);
+
+  if (!activeImage) {
+    return null;
+  }
+
+  const handlePointerMove = () => registerInteraction();
+
+  return (
+    <div className={styles.viewer}>
+      <div
+        className={styles.canvas}
+        ref={containerRef}
+        tabIndex={0}
+        onMouseMove={handlePointerMove}
+        onTouchStart={handlePointerMove}
+      >
+        <img src={activeImage.url} alt={activeImage.alt} loading="eager" />
+
+        <div className={styles.interactionLayer}>
+          <button
+            type="button"
+            className={`${styles.navigationZone} ${styles.navigationZoneLeft}`}
+            onClick={handlePrevious}
+            data-cursor-label="Precedente"
+            aria-label="Mostra fotografia precedente"
+          />
+          <button
+            type="button"
+            className={`${styles.navigationZone} ${styles.navigationZoneRight}`}
+            onClick={handleNext}
+            data-cursor-label="Successiva"
+            aria-label="Mostra fotografia successiva"
+          />
+        </div>
+
+        <div className={`${styles.pointerHint} ${styles.pointerHintLeft}`}>← Precedente</div>
+        <div className={`${styles.pointerHint} ${styles.pointerHintRight}`}>Successiva →</div>
+      </div>
+
+      <div className={styles.caption}>
+        {activeImage.caption && <span className={styles.captionTitle}>{activeImage.caption}</span>}
+        {captionDetails && <div className={styles.captionDetails}>{captionDetails}</div>}
+      </div>
+
+      <AnimatePresence>
+        {isActive && (
+          <motion.div
+            key="screensaver"
+            className={styles.screensaverBadge}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+          >
+            Screensaver attivo
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function wrapIndex(index: number, total: number) {
+  if (total === 0) return 0;
+  const mod = index % total;
+  return mod < 0 ? mod + total : mod;
+}
+
+function clampIndex(index: number, total: number) {
+  if (total === 0) return 0;
+  if (!Number.isFinite(index)) return 0;
+  const clamped = Math.max(0, Math.min(total - 1, index));
+  return clamped;
+}

--- a/components/RouteTransition.tsx
+++ b/components/RouteTransition.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { usePathname } from 'next/navigation';
+import { PropsWithChildren } from 'react';
+
+const transition = {
+  duration: 0.35,
+  ease: [0.4, 0, 0.2, 1]
+};
+
+export default function RouteTransition({ children }: PropsWithChildren) {
+  const pathname = usePathname();
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={transition}
+        style={{ minHeight: '100vh' }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/components/ThumbnailStrip.module.css
+++ b/components/ThumbnailStrip.module.css
@@ -1,0 +1,72 @@
+.wrapper {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 1rem 6vw 1.5rem;
+  background: linear-gradient(180deg, rgba(11, 11, 12, 0.1) 0%, rgba(11, 11, 12, 0.85) 35%, rgba(11, 11, 12, 0.95) 100%);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  z-index: 5;
+}
+
+.track {
+  display: flex;
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  scroll-behavior: smooth;
+}
+
+.track::-webkit-scrollbar {
+  height: 6px;
+}
+
+.track::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+}
+
+.thumbButton {
+  position: relative;
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.02);
+  padding: 0;
+  flex: 0 0 auto;
+  width: 120px;
+  height: 80px;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.thumbButton img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.thumbButton:hover {
+  transform: translateY(-3px);
+}
+
+.thumbActive {
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.thumbButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .wrapper {
+    padding: 0.75rem 1.5rem 1.25rem;
+  }
+
+  .thumbButton {
+    width: 96px;
+    height: 64px;
+  }
+}

--- a/components/ThumbnailStrip.tsx
+++ b/components/ThumbnailStrip.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { useEffect, useRef } from 'react';
+import styles from './ThumbnailStrip.module.css';
+import type { GalleryImage } from '@/lib/prismic';
+
+interface ThumbnailStripProps {
+  images: GalleryImage[];
+  activeIndex: number;
+  isOpen: boolean;
+  onSelect: (index: number) => void;
+}
+
+export default function ThumbnailStrip({
+  images,
+  activeIndex,
+  isOpen,
+  onSelect
+}: ThumbnailStripProps) {
+  const refs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const node = refs.current[activeIndex];
+    node?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+  }, [activeIndex, isOpen]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className={styles.wrapper}
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 40 }}
+          transition={{ duration: 0.3, ease: [0.33, 1, 0.68, 1] }}
+        >
+          <div className={styles.track}>
+            {images.map((image, index) => (
+              <button
+                key={image.id}
+                ref={(node) => {
+                  refs.current[index] = node;
+                }}
+                type="button"
+                className={`${styles.thumbButton} ${index === activeIndex ? styles.thumbActive : ''}`.trim()}
+                onClick={() => onSelect(index)}
+                data-cursor-label={`Vai a ${index + 1}`}
+                aria-current={index === activeIndex}
+                aria-label={`Vai allo scatto ${index + 1}`}
+              >
+                <img src={image.thumbnailUrl ?? image.url} alt={image.alt} loading="lazy" />
+              </button>
+            ))}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/hooks/useScreensaver.ts
+++ b/hooks/useScreensaver.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface Options {
+  delay?: number;
+  interval?: number;
+}
+
+export interface ScreensaverState {
+  isActive: boolean;
+  nextIndex: number | null;
+  registerInteraction: () => void;
+}
+
+export function useScreensaver(
+  totalImages: number,
+  currentIndex: number,
+  { delay = 25000, interval = 6000 }: Options = {}
+): ScreensaverState {
+  const [isActive, setIsActive] = useState(false);
+  const [nextIndex, setNextIndex] = useState<number | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const clearTimers = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const startTimer = useCallback(() => {
+    clearTimers();
+    if (totalImages <= 1) return;
+    timeoutRef.current = setTimeout(() => {
+      setIsActive(true);
+    }, delay);
+  }, [clearTimers, delay, totalImages]);
+
+  const registerInteraction = useCallback(() => {
+    setIsActive(false);
+    setNextIndex(null);
+    startTimer();
+  }, [startTimer]);
+
+  useEffect(() => {
+    startTimer();
+    return () => clearTimers();
+  }, [startTimer, clearTimers]);
+
+  useEffect(() => {
+    if (!isActive || totalImages <= 1) {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+
+    intervalRef.current = setInterval(() => {
+      if (totalImages <= 1) return;
+      let candidate = currentIndex;
+      let guard = 0;
+      while (candidate === currentIndex && guard < 10) {
+        candidate = Math.floor(Math.random() * totalImages);
+        guard += 1;
+      }
+      setNextIndex(candidate);
+    }, interval);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [currentIndex, interval, isActive, totalImages]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const events: Array<keyof WindowEventMap> = ['mousemove', 'keydown', 'click', 'touchstart'];
+    events.forEach((eventName) => {
+      window.addEventListener(eventName, registerInteraction, { passive: true });
+    });
+    return () => {
+      events.forEach((eventName) => {
+        window.removeEventListener(eventName, registerInteraction);
+      });
+    };
+  }, [registerInteraction]);
+
+  return { isActive, nextIndex, registerInteraction };
+}

--- a/lib/prismic.ts
+++ b/lib/prismic.ts
@@ -1,0 +1,416 @@
+import * as prismic from '@prismicio/client';
+
+export interface CollectionMetadataEntry {
+  label: string;
+  value: string;
+}
+
+export interface GalleryImageDetail {
+  label: string;
+  value: string;
+}
+
+export interface GalleryImage {
+  id: string;
+  url: string;
+  alt: string;
+  width?: number;
+  height?: number;
+  caption?: string;
+  descriptionHtml?: string;
+  thumbnailUrl?: string;
+  details?: GalleryImageDetail[];
+}
+
+export interface ResolvedCollection {
+  slug: string;
+  title: string;
+  summary?: string;
+  descriptionHtml?: string;
+  metadata: CollectionMetadataEntry[];
+  gallery: GalleryImage[];
+  order: number;
+}
+
+export interface CollectionSummary {
+  slug: string;
+  title: string;
+  summary?: string;
+  count: number;
+  order: number;
+}
+
+const repositoryName =
+  process.env.PRISMIC_REPOSITORY_NAME ?? process.env.NEXT_PUBLIC_PRISMIC_REPOSITORY_NAME ?? '';
+
+const FALLBACK_COLLECTIONS: ResolvedCollection[] = [
+  {
+    slug: 'work-01',
+    title: 'Linee di Ombra',
+    summary: 'Roma, 2021',
+    descriptionHtml:
+      '<p>Sequenza di camminate all\'alba tra i quartieri Ostiense e Garbatella: superfici industriali illuminate dalle prime luci e sagome di passanti distratti.</p>',
+    metadata: [
+      { label: 'Luogo', value: 'Roma, Italia' },
+      { label: 'Anno', value: '2021' },
+      { label: 'Pellicola', value: 'Kodak Portra 400' }
+    ],
+    order: 1,
+    gallery: [
+      {
+        id: 'work-01-1',
+        url: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=2000&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=400&q=60',
+        alt: 'Strada bagnata illuminata dal sole nascente',
+        caption: 'Linea di luce lungo via Ostiense',
+        width: 2000,
+        height: 1333
+      },
+      {
+        id: 'work-01-2',
+        url: 'https://images.unsplash.com/photo-1529119368496-2dfda6ec2804?auto=format&fit=crop&w=2000&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1529119368496-2dfda6ec2804?auto=format&fit=crop&w=400&q=60',
+        alt: 'Silhouette di una persona davanti a una vetrata industriale',
+        caption: 'Turno di notte alla Centrale Montemartini',
+        width: 2000,
+        height: 1333
+      },
+      {
+        id: 'work-01-3',
+        url: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=2000&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=400&q=60',
+        alt: 'Parete colorata con geometrie di luce',
+        caption: 'Garbatella, le geometrie del mattino',
+        width: 2000,
+        height: 1333
+      },
+      {
+        id: 'work-01-4',
+        url: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=2400&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=400&q=60',
+        alt: 'Scorcio di cortile romano con vegetazione',
+        caption: 'Una pausa tra i cortili',
+        width: 2400,
+        height: 1600
+      }
+    ]
+  },
+  {
+    slug: 'work-07',
+    title: 'Perimetro Notturno',
+    summary: 'Milano, 2022',
+    descriptionHtml:
+      '<p>Uno studio sui limiti della città al calare della notte: recinzioni, fari al sodio e tracce di passaggi recenti.</p>',
+    metadata: [
+      { label: 'Luogo', value: 'Milano, Italia' },
+      { label: 'Anno', value: '2022' },
+      { label: 'Attrezzatura', value: 'Fujifilm X100V' }
+    ],
+    order: 7,
+    gallery: [
+      {
+        id: 'work-07-1',
+        url: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=2000&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=400&q=60',
+        alt: 'Illuminazione arancione su strada notturna',
+        caption: 'Lamiera e neon in periferia',
+        width: 2000,
+        height: 1333
+      },
+      {
+        id: 'work-07-2',
+        url: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=2200&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=400&q=60',
+        alt: 'Parcheggio illuminato con persone che passano',
+        caption: 'Il turno del custode',
+        width: 2200,
+        height: 1466
+      },
+      {
+        id: 'work-07-3',
+        url: 'https://images.unsplash.com/photo-1526481280695-3c4692f9c1c1?auto=format&fit=crop&w=2100&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1526481280695-3c4692f9c1c1?auto=format&fit=crop&w=400&q=60',
+        alt: 'Catena metallica e luce al sodio',
+        caption: 'Perimetro 3B',
+        width: 2100,
+        height: 1400
+      }
+    ]
+  },
+  {
+    slug: 'work-13',
+    title: 'Attraversamenti',
+    summary: 'Palermo, 2020',
+    descriptionHtml:
+      '<p>Piccole storie di viaggio tra porto e centro storico. Ogni scatto è un frammento di conversazioni notturne.</p>',
+    metadata: [
+      { label: 'Luogo', value: 'Palermo, Italia' },
+      { label: 'Anno', value: '2020' },
+      { label: 'Formato', value: '6x7' }
+    ],
+    order: 13,
+    gallery: [
+      {
+        id: 'work-13-1',
+        url: 'https://images.unsplash.com/photo-1526481280695-3c4692f9c1c1?auto=format&fit=crop&w=2100&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1526481280695-3c4692f9c1c1?auto=format&fit=crop&w=400&q=60',
+        alt: 'Donna che cammina con valigia in controluce',
+        caption: 'Scalo merci',
+        width: 2100,
+        height: 1400
+      },
+      {
+        id: 'work-13-2',
+        url: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=2100&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=400&q=60',
+        alt: 'Taxi giallo con luci al neon',
+        caption: 'Rotatoria del porto',
+        width: 2100,
+        height: 1400
+      },
+      {
+        id: 'work-13-3',
+        url: 'https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=2000&q=80',
+        thumbnailUrl:
+          'https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=400&q=60',
+        alt: 'Coppia che attraversa un passaggio pedonale',
+        caption: 'Ultima corsa',
+        width: 2000,
+        height: 1333
+      }
+    ]
+  }
+];
+
+function getClient() {
+  if (!repositoryName) return null;
+  try {
+    return prismic.createClient(repositoryName, {
+      accessToken: process.env.PRISMIC_ACCESS_TOKEN || undefined,
+      fetchOptions: {
+        next: { revalidate: 60 },
+        cache: 'no-store'
+      }
+    });
+  } catch (error) {
+    console.warn('Impossibile creare il client Prismic:', error);
+    return null;
+  }
+}
+
+function parseOrder(value: unknown, fallback: number) {
+  if (typeof value === 'number') return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function pickThumbnail(image: any): string | undefined {
+  if (!image) return undefined;
+  if (typeof image.thumbnail_url === 'string') return image.thumbnail_url;
+  if (typeof image.thumbnailUrl === 'string') return image.thumbnailUrl;
+  if (image.thumbnails) {
+    const thumbnails = Object.values(image.thumbnails) as Array<{ url?: string }>;
+    const thumb = thumbnails.find((item) => typeof item?.url === 'string');
+    if (thumb?.url) return thumb.url;
+  }
+  if (typeof image.url === 'string') return image.url;
+  return undefined;
+}
+
+function parseImageDetails(item: Record<string, any>): GalleryImageDetail[] | undefined {
+  const details: GalleryImageDetail[] = [];
+  for (const [key, raw] of Object.entries(item)) {
+    if (key === 'image' || key === 'immagine' || key === 'caption') continue;
+    if (raw == null) continue;
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      details.push({ label: key.replace(/_/g, ' '), value: raw });
+    }
+  }
+  return details.length ? details : undefined;
+}
+
+function parseCollection(document: prismic.PrismicDocument<Record<string, any>>): ResolvedCollection | null {
+  const slug = document.uid || document.slugs?.[0] || document.id;
+  if (!slug) return null;
+
+  const titleField = document.data?.title as prismic.RichTextField | string | undefined;
+  const title =
+    (Array.isArray(titleField) ? prismic.asText(titleField) : titleField) || document.data?.name || slug;
+
+  const summaryField = document.data?.summary ?? document.data?.subtitle;
+  const summary =
+    typeof summaryField === 'string' && summaryField.trim().length > 0
+      ? summaryField.trim()
+      : Array.isArray(summaryField)
+      ? prismic.asText(summaryField as prismic.RichTextField)
+      : undefined;
+
+  const descriptionField = document.data?.description ?? document.data?.body;
+  const descriptionHtml = Array.isArray(descriptionField)
+    ? prismic.asHTML(descriptionField as prismic.RichTextField)
+    : typeof descriptionField === 'string'
+    ? descriptionField
+    : undefined;
+
+  const order = parseOrder(document.data?.order ?? document.data?.index, FALLBACK_COLLECTIONS.length + 1);
+
+  const metadata: CollectionMetadataEntry[] = [];
+  const metadataGroup = document.data?.metadata ?? document.data?.meta;
+  if (Array.isArray(metadataGroup)) {
+    for (const row of metadataGroup) {
+      const label = (row?.label || row?.titolo || '').toString().trim();
+      const value = (row?.value || row?.valore || '').toString().trim();
+      if (label && value) {
+        metadata.push({ label, value });
+      }
+    }
+  }
+
+  const candidateKeys = ['location', 'luogo', 'year', 'anno', 'camera', 'attrezzatura', 'format', 'formato'];
+  for (const key of candidateKeys) {
+    const raw = document.data?.[key];
+    if (typeof raw === 'string' && raw.trim()) {
+      const label = key
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, (match) => match.toUpperCase());
+      if (!metadata.some((entry) => entry.label === label)) {
+        metadata.push({ label, value: raw.trim() });
+      }
+    }
+  }
+
+  if (document.tags?.length) {
+    metadata.push({ label: 'Tag', value: document.tags.join(', ') });
+  }
+
+  const galleryRaw = (document.data?.gallery ?? document.data?.media ?? []) as Array<Record<string, any>>;
+  const gallery: GalleryImage[] = [];
+  galleryRaw.forEach((item, index) => {
+    const image = item?.image || item?.immagine || item;
+    if (!image || typeof image.url !== 'string') return;
+    const alt = image.alt || `${title} — scatto ${index + 1}`;
+    const captionField = item?.caption ?? item?.didascalia;
+    const caption = Array.isArray(captionField)
+      ? prismic.asText(captionField as prismic.RichTextField)
+      : typeof captionField === 'string'
+      ? captionField
+      : undefined;
+    const descriptionHtml = Array.isArray(captionField)
+      ? prismic.asHTML(captionField as prismic.RichTextField)
+      : undefined;
+
+    gallery.push({
+      id: `${slug}-${index}`,
+      url: image.url,
+      alt,
+      width: image.dimensions?.width,
+      height: image.dimensions?.height,
+      caption,
+      descriptionHtml,
+      thumbnailUrl: pickThumbnail(image),
+      details: parseImageDetails(item)
+    });
+  });
+
+  if (!gallery.length) {
+    return null;
+  }
+
+  return {
+    slug,
+    title,
+    summary,
+    descriptionHtml,
+    metadata,
+    gallery,
+    order
+  };
+}
+
+export async function getCollectionsIndex(): Promise<CollectionSummary[]> {
+  const client = getClient();
+  if (client) {
+    try {
+      const documents = await client.getAllByType('collection', {
+        orderings: [{ field: 'my.collection.order', direction: 'asc' }],
+        pageSize: 100
+      });
+      const parsed = documents
+        .map((doc) => {
+          const collection = parseCollection(doc as prismic.PrismicDocument<Record<string, any>>);
+          if (!collection) return null;
+          return {
+            slug: collection.slug,
+            title: collection.title,
+            summary: collection.summary,
+            count: collection.gallery.length,
+            order: collection.order
+          } satisfies CollectionSummary;
+        })
+        .filter((value): value is CollectionSummary => Boolean(value));
+      if (parsed.length) {
+        return parsed.sort((a, b) => a.order - b.order);
+      }
+    } catch (error) {
+      console.warn('Impossibile caricare la lista delle collezioni da Prismic:', error);
+    }
+  }
+
+  return FALLBACK_COLLECTIONS.map((collection) => ({
+    slug: collection.slug,
+    title: collection.title,
+    summary: collection.summary,
+    count: collection.gallery.length,
+    order: collection.order
+  })).sort((a, b) => a.order - b.order);
+}
+
+export async function getCollection(slug: string): Promise<ResolvedCollection | null> {
+  const client = getClient();
+  if (client) {
+    try {
+      const document = await client.getByUID('collection', slug, {
+        fetchLinks: []
+      });
+      const parsed = parseCollection(document as prismic.PrismicDocument<Record<string, any>>);
+      if (parsed) return parsed;
+    } catch (error: any) {
+      if (error?.status !== 404) {
+        console.warn(`Errore durante il caricamento della collezione ${slug}:`, error);
+      }
+    }
+  }
+
+  const fallback = FALLBACK_COLLECTIONS.find((item) => item.slug === slug);
+  return fallback ?? null;
+}
+
+export async function getCollectionSlugs(): Promise<string[]> {
+  const client = getClient();
+  if (client) {
+    try {
+      const documents = await client.getAllByType('collection', {
+        fetch: ['uid']
+      });
+      const slugs = documents
+        .map((doc) => doc.uid || doc.slugs?.[0])
+        .filter((value): value is string => Boolean(value));
+      if (slugs.length) {
+        return slugs;
+      }
+    } catch (error) {
+      console.warn('Impossibile recuperare le route statiche da Prismic:', error);
+    }
+  }
+
+  return FALLBACK_COLLECTIONS.map((collection) => collection.slug);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'images.prismic.io' },
+      { protocol: 'https', hostname: 'images.cdn.prismic.io' },
+      { protocol: 'https', hostname: 'images.unsplash.com' },
+      { protocol: 'https', hostname: 'picsum.photos' }
+    ]
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "codex",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@prismicio/client": "^7.3.1",
+    "@prismicio/react": "^2.5.1",
+    "framer-motion": "^11.0.0",
+    "next": "^14.2.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "typescript": "^5.5.4"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- build a Prismic-driven index page that orders collections and surfaces textual metadata with human-readable slugs
- add the dynamic collection route with gallery header, synchronized thumbnail strip, and URL-aware navigation helpers
- implement the interactive gallery viewer with screensaver mode, custom cursor, and framer-motion route fades

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org/@prismicio/client)*

------
https://chatgpt.com/codex/tasks/task_e_68d09e505f84832b913a98f26a3452d3