### PR TITLE
Create brutalist portfolio experience

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,21 +1,18 @@
 :root {
-  --foreground-rgb: 15, 23, 42;
-  --background-start-rgb: 255, 255, 255;
-  --background-end-rgb: 226, 232, 240;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 226, 232, 240;
-    --background-start-rgb: 15, 23, 42;
-    --background-end-rgb: 2, 6, 23;
-  }
+  --bg: #0a0a0a;
+  --fg: #f6f6ef;
+  --muted: #c7c7c7;
+  --accent: #ff4d00;
+  --accent-2: #7cf2ff;
+  --card: #111111;
+  --stroke: rgba(255, 255, 255, 0.12);
+  --grid: rgba(255, 255, 255, 0.04);
 }
 
 * {
   box-sizing: border-box;
-  padding: 0;
   margin: 0;
+  padding: 0;
 }
 
 html,
@@ -25,50 +22,364 @@ body {
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-    to bottom,
-    transparent,
-    rgb(var(--background-end-rgb))
-  )
-    rgb(var(--background-start-rgb));
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
-  line-height: 1.6;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 77, 0, 0.12), transparent 30%),
+    radial-gradient(circle at 80% 0%, rgba(124, 242, 255, 0.1), transparent 25%),
+    linear-gradient(135deg, #070707 0%, #0c0c0c 50%, #050505 100%);
+  color: var(--fg);
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.7;
+  letter-spacing: 0.01em;
+  min-height: 100vh;
+}
+
+::selection {
+  background: var(--accent);
+  color: #050505;
 }
 
 a {
   color: inherit;
-  text-decoration: underline;
 }
 
 a:hover {
-  text-decoration: none;
+  color: var(--accent-2);
 }
 
-main.container {
+.page {
   margin: 0 auto;
-  max-width: 700px;
+  max-width: 1200px;
   padding: 4rem 1.5rem 5rem;
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 3rem;
+  position: relative;
 }
 
-main.container h1 {
-  font-size: clamp(2.5rem, 5vw, 3rem);
-  font-weight: 600;
+.page::before {
+  content: "";
+  position: absolute;
+  inset: 1.5rem;
+  border: 1px solid var(--grid);
+  pointer-events: none;
+  border-radius: 24px;
 }
 
-main.container section {
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  border-radius: 0.75rem;
-  padding: 1.5rem;
-  background: rgba(148, 163, 184, 0.08);
+.hero {
+  position: relative;
+  display: grid;
+  gap: 1.5rem;
+  padding: 2.5rem;
+  background: var(--card);
+  border-radius: 24px;
+  border: 1px solid var(--stroke);
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.35);
+  isolation: isolate;
 }
 
-main.container section h2 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border: 1px dashed var(--grid);
+  border-radius: 18px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--stroke);
+  background: #0f0f0f;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  z-index: 1;
+}
+
+.hero h1 {
+  font-size: clamp(2.8rem, 4vw, 3.75rem);
+  line-height: 1.1;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  z-index: 1;
+}
+
+.accent {
+  color: var(--accent);
+  text-shadow: 0 0 25px rgba(255, 77, 0, 0.4);
+}
+
+.lede {
+  font-size: 1.05rem;
+  color: var(--muted);
+  max-width: 820px;
+  z-index: 1;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  z-index: 1;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.9rem 1.4rem;
+  border-radius: 14px;
+  border: 1px solid var(--stroke);
+  text-decoration: none;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #0f0f0f;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease,
+    background 0.2s ease;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--accent) 0%, #ff9640 100%);
+  color: #050505;
+  box-shadow: 0 10px 30px rgba(255, 77, 0, 0.35);
+}
+
+.btn.ghost {
+  background: transparent;
+  color: var(--fg);
+}
+
+.btn.small {
+  padding: 0.75rem 1.2rem;
+  font-size: 0.9rem;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.45);
+  color: #0a0a0a;
+  background: var(--accent-2);
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  z-index: 1;
+}
+
+.stat {
+  padding: 1rem;
+  border: 1px solid var(--stroke);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.35rem;
+}
+
+.stat-value {
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.section {
+  display: grid;
+  gap: 1.25rem;
+  background: var(--card);
+  padding: 2.25rem;
+  border-radius: 24px;
+  border: 1px solid var(--stroke);
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25);
+}
+
+.section-head h2 {
+  font-size: 1.8rem;
+  letter-spacing: -0.01em;
+}
+
+.section-head p {
+  color: var(--muted);
+  max-width: 760px;
+  margin-top: 0.4rem;
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  padding: 1.4rem;
+  border: 1px solid var(--stroke);
+  border-radius: 18px;
+  background: #0f0f0f;
+  display: grid;
+  gap: 0.75rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 77, 0, 0.08), transparent 50%);
+  pointer-events: none;
+}
+
+.card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.card h3 {
+  font-size: 1.3rem;
+}
+
+.card-body {
+  color: var(--muted);
+}
+
+.card-link {
+  text-decoration: none;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.tag-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--stroke);
+  border-radius: 10px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  background: rgba(124, 242, 255, 0.04);
+}
+
+.manifesto-list {
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.manifesto-list li {
+  padding: 0.85rem 1rem;
+  border-left: 3px solid var(--accent);
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 12px;
+}
+
+.process-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1rem;
+}
+
+.step {
+  border: 1px solid var(--stroke);
+  padding: 1rem;
+  border-radius: 16px;
+  background: #0f0f0f;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.step-number {
+  font-weight: 800;
+  color: var(--accent-2);
+  font-size: 1.1rem;
+}
+
+.step h3 {
+  margin-bottom: 0.25rem;
+}
+
+.step p {
+  color: var(--muted);
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.2rem;
+  align-items: start;
+}
+
+.contact-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  text-decoration: none;
+  border-bottom: 1px solid var(--stroke);
+  padding-bottom: 0.15rem;
+  margin-right: 0.75rem;
+}
+
+.contact-link:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.contact-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-size: 0.8rem;
+  margin-bottom: 0.35rem;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 3rem 1.1rem 4rem;
+  }
+
+  .page::before {
+    inset: 1rem;
+  }
+
+  .hero,
+  .section {
+    padding: 1.6rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.3rem, 9vw, 3rem);
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,8 +5,9 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Codex",
-  description: "A Next.js starter configured with Prismic",
+  title: "Portfolio Brutalista | Codex Studio",
+  description:
+    "Un portfolio brutalista e contemporaneo per esperienze digitali radicali, installazioni e identità visive.",
 };
 
 export default function RootLayout({
@@ -15,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="it">
       <body className={inter.className}>{children}</body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,203 @@
 import Link from "next/link";
 
+const projects = [
+  {
+    title: "Syntropic Atlas",
+    description:
+      "Un archivio vivo di pattern generativi che mescola brutalismo tipografico e geometrie neon.",
+    tags: ["creative coding", "webGL", "data-poesia"],
+    link: "https://example.com/atlas",
+  },
+  {
+    title: "Hyperbody Studio",
+    description:
+      "Installazione digitale che unisce motion design, architetture sonore e interazioni tattili.",
+    tags: ["immersive", "sound design", "experiential"],
+    link: "https://example.com/hyperbody",
+  },
+  {
+    title: "Radical Library",
+    description:
+      "Un sistema di lettura curatoriale per riviste indipendenti, con layout modulare e micro-animazioni crude.",
+    tags: ["editorial", "UX research", "accessibility"],
+    link: "https://example.com/library",
+  },
+  {
+    title: "Off-Grid Identities",
+    description:
+      "Serie di identità visive per festival sonici, guidate da algoritmi di distorsione controllata.",
+    tags: ["brand systems", "algoritmi", "motion"],
+    link: "https://example.com/offgrid",
+  },
+];
+
+const principles = [
+  "Brutalismo come linguaggio sincero: blocchi netti, ritmo materico, zero decorazioni inutili.",
+  "Modernità radicale: tipografia audace, spazi drammatici, interazioni che restano nella memoria.",
+  "Accesso totale: performance, leggibilità e cura per chi naviga da qualsiasi dispositivo.",
+  "Collaborazioni che fanno scintille: dialoghi con artisti, musei, brand e istituzioni curiose.",
+];
+
+const process = [
+  {
+    title: "Ricerca Obliqua",
+    detail: "Mappe visive, suoni, materiali. Ogni progetto parte con immersioni e sketch multisensoriali.",
+  },
+  {
+    title: "Progettazione Brut",
+    detail: "Griglie ferree, cromie acide, test continui su tipografia e micro-interazioni responsivi.",
+  },
+  {
+    title: "Assemblaggio Vivo",
+    detail: "Code, prototipi, live sessions con il cliente. Ogni release è un atto performativo.",
+  },
+];
+
 export default function Home() {
   return (
-    <main className="container">
-      <h1>Next.js + Prismic starter</h1>
-      <p>
-        The project is ready to connect to your Prismic repository. Configure the
-        <code>.env.local</code> file with your repository name and access token,
-        then start the development server with <code>npm run dev</code>.
-      </p>
-      <section>
-        <h2>Prismic check</h2>
-        <p>
-          You can verify the SDK connection by visiting the
-          {" "}
-          <Link href="/api/prismic-test?type=page">/api/prismic-test</Link>
-          {" "}
-          endpoint once your environment variables are in place.
+    <main className="page">
+      <header className="hero">
+        <div className="badge">Portfolio 2024 · Brutal &amp; Bold</div>
+        <h1>
+          Creazioni digitali <span className="accent">brutaliste</span> con cuore
+          contemporaneo.
+        </h1>
+        <p className="lede">
+          Siti, installazioni e identità visive che parlano la lingua dei musei,
+          dei club e delle gallerie. Un portfolio come poster urbano: tagliente,
+          luminoso, irresistibilmente tattile.
         </p>
+        <div className="hero-actions">
+          <Link className="btn primary" href="#projects">
+            Esplora le opere
+          </Link>
+          <Link className="btn ghost" href="#contact">
+            Proponi una collaborazione
+          </Link>
+        </div>
+        <div className="hero-grid">
+          <div className="stat">
+            <p className="stat-label">Focus</p>
+            <p className="stat-value">Arte digitale · Identità · Web immersivi</p>
+          </div>
+          <div className="stat">
+            <p className="stat-label">Mood</p>
+            <p className="stat-value">Spigoli vivi, colori acidi, modernismo affettuoso</p>
+          </div>
+          <div className="stat">
+            <p className="stat-label">Disponibilità</p>
+            <p className="stat-value">Nuovi progetti da ottobre</p>
+          </div>
+        </div>
+      </header>
+
+      <section className="section" id="projects">
+        <div className="section-head">
+          <h2>Selezione di opere</h2>
+          <p>
+            Ogni progetto è una scultura digitale: tipografia estrema, griglie
+            rigide, pixel che vibrano. Il brut diventa lusso quando la cura è
+            maniacale.
+          </p>
+        </div>
+        <div className="project-grid">
+          {projects.map((project) => (
+            <article className="card" key={project.title}>
+              <div className="card-top">
+                <p className="card-eyebrow">Opera</p>
+                <a className="card-link" href={project.link}>
+                  visita ↗
+                </a>
+              </div>
+              <h3>{project.title}</h3>
+              <p className="card-body">{project.description}</p>
+              <div className="tag-row">
+                {project.tags.map((tag) => (
+                  <span className="tag" key={tag}>
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section manifesto">
+        <div className="section-head">
+          <h2>Manifesto brutale</h2>
+          <p>
+            Principi scolpiti nel cemento, lucidati con la tecnologia. Ogni
+            riga è un impegno creativo.
+          </p>
+        </div>
+        <ul className="manifesto-list">
+          {principles.map((line) => (
+            <li key={line}>{line}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="section process">
+        <div className="section-head">
+          <h2>Processo</h2>
+          <p>
+            Una corsa ad alta tensione tra ricerca artistica e prototipazione
+            immediata.
+          </p>
+        </div>
+        <div className="process-grid">
+          {process.map((step, index) => (
+            <div className="step" key={step.title}>
+              <span className="step-number">0{index + 1}</span>
+              <div>
+                <h3>{step.title}</h3>
+                <p>{step.detail}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="section contact" id="contact">
+        <div className="section-head">
+          <h2>Parliamone</h2>
+          <p>
+            Commissioni, residenze artistiche, workshop: se hai una visione
+            radicale, costruiamola insieme.
+          </p>
+        </div>
+        <div className="contact-grid">
+          <div>
+            <p className="label">Email</p>
+            <a href="mailto:ciao@brutartist.studio" className="contact-link">
+              ciao@brutartist.studio
+            </a>
+          </div>
+          <div>
+            <p className="label">Social</p>
+            <div className="contact-row">
+              <a href="https://instagram.com" className="contact-link">
+                Instagram
+              </a>
+              <a href="https://dribbble.com" className="contact-link">
+                Dribbble
+              </a>
+              <a href="https://www.behance.net" className="contact-link">
+                Behance
+              </a>
+            </div>
+          </div>
+          <div>
+            <p className="label">Newsletter</p>
+            <p className="muted">
+              Aggiornamenti su nuove installazioni, ricerche e release pubbliche.
+            </p>
+            <a className="btn primary small" href="https://example.com/newsletter">
+              Iscriviti ora
+            </a>
+          </div>
+        </div>
       </section>
     </main>
   );

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited


### PR DESCRIPTION
## Summary
- replace starter content with a brutalist, Italian-language portfolio experience featuring projects, manifesto, process, and contact sections
- craft bold visual system with neon brutalist styling, responsive grids, and CTA buttons
- refresh site metadata to match the new portfolio identity

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f7b0066e8832b9ada3b81718fcc6d)